### PR TITLE
Refactor sign-up feature

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,5 +21,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters    
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 end

--- a/features/signup_to_account.feature
+++ b/features/signup_to_account.feature
@@ -6,12 +6,12 @@ Feature: Signup to an account
   Scenario: As a user I would like to signup to an account
     Given I am on the landing page
     When I click on the "Sign up" button
-    Then I should goto the registration form
-    When I fill in "Name" with "Bob"
+    And I fill in "Name" with "Bob"
     And I fill in "Email" with "bob@example.com"
-    And I fill in "Password" with "foobar"
-    And I fill in "Password confirmation" with "foobar"
+    And I fill in "Password" with "mypassword"
+    And I fill in "Password confirmation" with "mypassword"
     And I click on the "Create" button
-    Then I should be on the users registration page   
+    Then I should be on the landing page
+    And I should see a message saying "Welcome! You have signed up successfully."
 
 


### PR DESCRIPTION
## Refactor sign-up feature
PT: https://www.pivotaltracker.com/story/show/160580635

The previous iteration of this feature was not testing what it was supposed to. We did not really sign up to an account, but our tests passed because we adapted our test (cheated basically) to fit the path that was provided to us after pressing the create button.

Now the code has been refactored to actually make sure that we land on the root path and that we are greeted with a message confirming everything worked. 

To make it work we also had to fix a flaw in the application controller which didn't permit the name field to be submitted. A permission devise sanitizer for this parameter was therefore added.