### PR TITLE
Send to multiple users feature using selenium and chromedriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ end
 
 group :development, :test do
   gem 'cucumber-rails', require: false
+  gem 'chromedriver-helper'
+  gem 'selenium-webdriver'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (8.0.0)
     autoprefixer-rails (8.6.4)
       execjs
@@ -63,10 +65,15 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chosen-rails (1.8.3)
       coffee-rails (>= 3.2)
       railties (>= 3.0)
       sass-rails (>= 3.2)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -121,6 +128,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -215,6 +223,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubyzip (1.2.2)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -226,6 +235,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     spring (2.0.2)
@@ -266,6 +278,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   chosen-rails
+  chromedriver-helper
   cucumber-rails
   database_cleaner
   devise
@@ -284,6 +297,7 @@ DEPENDENCIES
   rake (~> 11.1, >= 11.1.2)
   rspec-rails
   sass-rails (~> 5.0)
+  selenium-webdriver
   shoulda-matchers
   spring
   sprockets (~> 3.7.2)

--- a/features/multiple_send.feature
+++ b/features/multiple_send.feature
@@ -16,4 +16,8 @@ Feature: Send to multiple people
         Given I am on the landing page
         And I click on the "Inbox" button
         And I click on the "Compose" button
-        
+        And I select multiple "Recipients" named "Tore" and "Gustav"
+        And I fill in "Subject" with "Hello to ya'll!"
+        And I fill in "conversation_body" with "How are you guys?"            
+        And I click the "Send Message" button
+        Then I should have a message in my inbox with the content "Your message was successfully sent!"

--- a/features/multiple_send.feature
+++ b/features/multiple_send.feature
@@ -1,0 +1,19 @@
+Feature: Send to multiple people
+    As a user 
+    In order to save time
+    I would like to be able to send messages to multiple users at once
+
+    Background: User is Logged in and sends message
+        Given the following user is in database
+        | email              | password   | name |
+        | tore@example.com   | foobarbar  | Tore |
+        | olof@example.com   | mypassword | Olof |
+        | gustav@example.com | mypassword | Gustav |
+        And I should be logged in as "Olof"
+    
+    @javascript
+    Scenario: As a user I want to send a message to multiple users
+        Given I am on the landing page
+        And I click on the "Inbox" button
+        And I click on the "Compose" button
+        

--- a/features/multiple_send.feature
+++ b/features/multiple_send.feature
@@ -1,6 +1,6 @@
 Feature: Send to multiple people
     As a user 
-    In order to save time
+    In order to have a conversation
     I would like to be able to send messages to multiple users at once
 
     Background: User is Logged in and sends message

--- a/features/step_definitions/inbox_definitions_step.rb
+++ b/features/step_definitions/inbox_definitions_step.rb
@@ -20,6 +20,12 @@ Then("I select {string} named {string}") do |field, recipient|
   select recipient, from: field
 end
 
+Given("I select multiple {string} named {string} and {string}") do |field, recipient1, recipient2|
+  select recipient1, from: field
+  page.driver.browser.action.key_down(:shift).perform
+  select recipient2, from: field  
+end
+
 Then("I should have a message in my inbox with the content {string}") do |message|
   expect(page).to have_content message
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,11 +7,11 @@ rescue NameError
 end
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
-Chromedriver.set_version '2.33'
+Chromedriver.set_version '2.36'
 
 Capybara.register_driver :selenium do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
-      args: %w( headless disable-popup-blocking disable-infobars)
+      args: %w(disable-popup-blocking disable-infobars window-size=1900,1400)
   )
 
   Capybara::Selenium::Driver.new(

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,3 +7,17 @@ rescue NameError
 end
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
+Chromedriver.set_version '2.33'
+
+Capybara.register_driver :selenium do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+      args: %w( headless disable-popup-blocking disable-infobars)
+  )
+
+  Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      options: options
+  )
+end
+Capybara.javascript_driver = :selenium


### PR DESCRIPTION
## Send to multiple people
PT: https://www.pivotaltracker.com/story/show/160682171

This feature step uses Selenium and Chromedriver to run a feature test for composing a message and sending it to multiple users. The step definitions for selecting multiple users using the shift-key was added to the inbox_step - definition file and might be suited in the conversations file. This is something that will be done in a separate refactor-PR.